### PR TITLE
drag grok api client into the grok-4.20 era

### DIFF
--- a/src/api/grokClient.test.ts
+++ b/src/api/grokClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { GrokClient, FALLBACK_MODELS, type GrokChatMessage } from './grokClient';
+import { GrokClient, type GrokChatMessage } from './grokClient';
 
 describe('GrokClient', () => {
   it('parses model list responses', async () => {
@@ -63,7 +63,43 @@ describe('GrokClient', () => {
     ]);
   });
 
-  it('returns fallbacks when only grok-2 models are available', async () => {
+  it('filters out grok-imagine models from the API response', async () => {
+    const fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: 'grok-4',
+            name: 'Grok 4',
+          },
+          {
+            id: 'grok-imagine-image',
+            name: 'Grok Imagine Image',
+          },
+          {
+            id: 'grok-imagine-image-pro',
+            name: 'Grok Imagine Image Pro',
+          },
+          {
+            id: 'grok-imagine-video',
+            name: 'Grok Imagine Video',
+          },
+        ],
+      }),
+    })) as unknown as typeof global.fetch;
+
+    const client = new GrokClient({ fetchImpl: fetch });
+    const models = await client.listModels('sk-test');
+
+    expect(models).toEqual([
+      {
+        id: 'grok-4',
+        name: 'Grok 4',
+      },
+    ]);
+  });
+
+  it('throws when no compatible models remain after filtering', async () => {
     const fetch = vi.fn(async () => ({
       ok: true,
       json: async () => ({
@@ -73,35 +109,26 @@ describe('GrokClient', () => {
             name: 'Grok 2',
           },
           {
-            id: 'grok-2-mini',
-            name: 'Grok 2 Mini',
+            id: 'grok-imagine-image',
+            name: 'Grok Imagine Image',
           },
         ],
       }),
     })) as unknown as typeof global.fetch;
 
     const client = new GrokClient({ fetchImpl: fetch });
-    const models = await client.listModels('sk-test');
-
-    expect(models).toEqual(FALLBACK_MODELS);
+    await expect(client.listModels('sk-test')).rejects.toThrow('No compatible models available');
   });
 
-  it('falls back to default models on error', async () => {
+  it('throws on HTTP error', async () => {
     const fetch = vi.fn(async () => ({
       ok: false,
       status: 401,
       text: async () => 'unauthorized',
     })) as unknown as typeof global.fetch;
 
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
     const client = new GrokClient({ fetchImpl: fetch });
-    const models = await client.listModels('sk-test');
-
-    expect(models).toEqual(FALLBACK_MODELS);
-    expect(warnSpy).toHaveBeenCalled();
-
-    warnSpy.mockRestore();
+    await expect(client.listModels('sk-test')).rejects.toThrow('Grok API request failed (401)');
   });
 
   it('falls back to non-streaming completion when streaming is unavailable', async () => {
@@ -189,10 +216,16 @@ describe('GrokClient', () => {
     expect(response.choices[0]?.finishReason).toBe('stop');
   });
 
-  it('disables citations in search parameters when search is enabled', async () => {
-    const fetch = vi.fn(async (_url, init?: RequestInit) => {
+  it('does not send search_parameters when search is enabled', async () => {
+    const fetch = vi.fn(async (_url: string, init?: RequestInit) => {
       const payload = JSON.parse((init?.body as string) ?? '{}');
-      expect(payload.search_parameters).toEqual({ return_citations: false });
+      expect(payload.search_parameters).toBeUndefined();
+      expect(payload.tools).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'web_search' }),
+          expect.objectContaining({ type: 'x_search' }),
+        ]),
+      );
       return {
         ok: true,
         json: async () => ({

--- a/src/api/grokClient.ts
+++ b/src/api/grokClient.ts
@@ -6,16 +6,6 @@ import { z } from 'zod';
 
 const DEFAULT_BASE_URL = import.meta.env.VITE_GROK_API_BASE ?? 'https://api.x.ai/v1';
 
-/**
- * Static list used when the API is unreachable or returns an unexpected payload.
- */
-export const FALLBACK_MODELS: GrokModel[] = [
-  { id: 'grok-4', name: 'Grok 4' },
-  { id: 'grok-3-mini', name: 'Grok 3 Mini' },
-  { id: 'grok-3-fast', name: 'Grok 3 Fast' },
-  { id: 'grok-3-mini-fast', name: 'Grok 3 Mini Fast' },
-  { id: 'grok-3', name: 'Grok 3' },
-];
 
 /**
  * Options for constructing a GrokClient instance.
@@ -41,7 +31,10 @@ export interface GrokMcpTool {
   type: 'mcp';
   server_url: string;
   server_label: string;
+  server_description?: string;
   allowed_tool_names?: string[];
+  authorization?: string;
+  extra_headers?: Record<string, string>;
 }
 
 export interface GrokCodeInterpreterTool {
@@ -50,6 +43,10 @@ export interface GrokCodeInterpreterTool {
 
 export interface GrokXSearchTool {
   type: 'x_search';
+  allowed_x_handles?: string[];
+  excluded_x_handles?: string[];
+  from_date?: string;
+  to_date?: string;
   enable_image_understanding?: boolean;
   enable_video_understanding?: boolean;
 }
@@ -115,8 +112,13 @@ const grokModelsResponseSchema = z.object({
     .optional(),
 });
 
+interface WebSearchFilters {
+  allowed_domains?: string[];
+  excluded_domains?: string[];
+}
+
 type DefaultResponsesTool =
-  | { type: 'web_search'; enable_image_understanding?: boolean }
+  | { type: 'web_search'; filters?: WebSearchFilters; enable_image_understanding?: boolean }
   | { type: 'x_search' };
 
 const DEFAULT_RESPONSES_TOOLS: DefaultResponsesTool[] = [
@@ -134,19 +136,10 @@ interface ResponsesApiPayload {
   input: ResponsesApiInputItem[];
   temperature?: number;
   tools?: ResponsesApiTool[];
-  search_parameters?: ResponsesSearchParameters;
   stream?: boolean;
 }
 
 type ResponsesApiTool = DefaultResponsesTool | GrokTool;
-
-interface ResponsesSearchParameters {
-  mode?: 'off' | 'auto' | 'on';
-  return_citations?: boolean;
-  sources?: unknown[];
-  from_date?: string;
-  to_date?: string;
-}
 
 interface ResponsesApiResponse {
   id: string;
@@ -202,38 +195,35 @@ export class GrokClient {
    * Falls back to a static list when the request fails or the payload is invalid.
    */
   async listModels(apiKey: string): Promise<GrokModel[]> {
-    try {
-      const response = await this.fetchImpl(`${this.baseUrl}/models`, {
-        headers: this.createHeaders(apiKey),
-      });
+    const response = await this.fetchImpl(`${this.baseUrl}/models`, {
+      headers: this.createHeaders(apiKey),
+    });
 
-      if (!response.ok) {
-        throw createHttpError(response.status, await response.text());
-      }
-
-      const payload = await response.json();
-      const parsed = grokModelsResponseSchema.safeParse(payload);
-
-      if (!parsed.success || !parsed.data.data) {
-        return FALLBACK_MODELS;
-      }
-
-      const filteredModels = parsed.data.data.filter((model) => !model.id.startsWith('grok-2'));
-
-      if (filteredModels.length === 0) {
-        return FALLBACK_MODELS;
-      }
-
-      return filteredModels.map((model) => ({
-        id: model.id,
-        name: model.name ?? model.id,
-        description: model.description,
-        maxTokens: model.max_tokens,
-      }));
-    } catch (error) {
-      console.warn('Failed to fetch Grok models, falling back to defaults:', error);
-      return FALLBACK_MODELS;
+    if (!response.ok) {
+      throw createHttpError(response.status, await response.text());
     }
+
+    const payload = await response.json();
+    const parsed = grokModelsResponseSchema.safeParse(payload);
+
+    if (!parsed.success || !parsed.data.data?.length) {
+      throw new Error('Unexpected model list response');
+    }
+
+    const filteredModels = parsed.data.data.filter(
+      (model) => !model.id.startsWith('grok-2') && !model.id.startsWith('grok-imagine'),
+    );
+
+    if (filteredModels.length === 0) {
+      throw new Error('No compatible models available');
+    }
+
+    return filteredModels.map((model) => ({
+      id: model.id,
+      name: model.name ?? model.id,
+      description: model.description,
+      maxTokens: model.max_tokens,
+    }));
   }
 
   /**
@@ -412,10 +402,6 @@ function buildResponsesPayload(request: GrokChatRequest, stream: boolean): Respo
       ? DEFAULT_RESPONSES_TOOLS.filter((tool) => tool.type !== 'x_search')
       : DEFAULT_RESPONSES_TOOLS;
     tools.push(...defaults);
-    // Context7 xAI docs: return_citations defaults to true; disable to keep transcript clean.
-    payload.search_parameters = {
-      return_citations: false,
-    };
   }
 
   if (request.tools?.length) {

--- a/src/features/setup/useGrokModels.test.tsx
+++ b/src/features/setup/useGrokModels.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { GrokClientContext } from '@/api/grokClientContext';
-import { FALLBACK_MODELS, type GrokModel } from '@/api/grokClient';
+import type { GrokModel } from '@/api/grokClient';
 import { useGrokModels } from './useGrokModels';
 import { useSessionStore } from '@/state/sessionStore';
 import { createMockClient, resetSessionStore } from '@/test/testUtils';
@@ -12,7 +12,7 @@ describe('useGrokModels', () => {
     resetSessionStore();
   });
 
-  it('returns fallback models when no API key is set', async () => {
+  it('returns empty models when no API key is set', async () => {
     const listModels = vi.fn();
     const client = createMockClient({ listModels });
     const wrapper = ({ children }: { children: ReactNode }) => (
@@ -24,7 +24,7 @@ describe('useGrokModels', () => {
     const { result } = renderHook(() => useGrokModels(), { wrapper });
 
     expect(result.current.status).toBe('idle');
-    expect(result.current.models).toEqual(FALLBACK_MODELS);
+    expect(result.current.models).toEqual([]);
     expect(listModels).not.toHaveBeenCalled();
   });
 
@@ -56,7 +56,7 @@ describe('useGrokModels', () => {
     expect(listModels).toHaveBeenCalledTimes(1);
   });
 
-  it('falls back to defaults on fetch error and surfaces the error message', async () => {
+  it('sets error status on fetch failure and returns empty models', async () => {
     resetSessionStore();
     useSessionStore.getState().setApiKey('sk-test', { remember: false });
 
@@ -77,7 +77,7 @@ describe('useGrokModels', () => {
       expect(result.current.status).toBe('error');
     });
 
-    expect(result.current.models).toEqual(FALLBACK_MODELS);
+    expect(result.current.models).toEqual([]);
     expect(result.current.error).toBe('network down');
   });
 });

--- a/src/features/setup/useGrokModels.ts
+++ b/src/features/setup/useGrokModels.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { FALLBACK_MODELS, type GrokModel } from '@/api/grokClient';
+import type { GrokModel } from '@/api/grokClient';
 import { useGrokClient } from '@/api/useGrokClient';
 import { useSessionStore } from '@/state/sessionStore';
 
@@ -7,23 +7,21 @@ export type ModelsStatus = 'idle' | 'loading' | 'success' | 'error';
 
 /**
  * Fetches and caches available Grok models for selection in the setup flow.
- * Automatically falls back to a static list when the user has no API key or the
- * network call fails.
  */
 export function useGrokModels() {
   const client = useGrokClient();
   const apiKey = useSessionStore((state) => state.apiKey);
-  const [models, setModels] = useState<GrokModel[]>(FALLBACK_MODELS);
+  const [models, setModels] = useState<GrokModel[]>([]);
   const [status, setStatus] = useState<ModelsStatus>(apiKey ? 'loading' : 'idle');
   const [error, setError] = useState<string | null>(null);
   const inFlight = useRef<AbortController | null>(null);
 
   const fetchModels = useCallback(async () => {
     if (!apiKey) {
-      setModels(FALLBACK_MODELS);
+      setModels([]);
       setStatus('idle');
       setError(null);
-      return FALLBACK_MODELS;
+      return [];
     }
 
     inFlight.current?.abort();
@@ -43,13 +41,13 @@ export function useGrokModels() {
       return results;
     } catch (err) {
       if (controller.signal.aborted) {
-        return FALLBACK_MODELS;
+        return [];
       }
       const message = err instanceof Error ? err.message : String(err);
       setError(message);
       setStatus('error');
-      setModels(FALLBACK_MODELS);
-      return FALLBACK_MODELS;
+      setModels([]);
+      return [];
     }
   }, [apiKey, client]);
 


### PR DESCRIPTION
## Summary

- **Killed the fallback model list** — grok-3-fast and grok-3-mini-fast have been dead for a while now, so pretending they exist as a safety net was more like a safety lie. `listModels` now throws on failure like a responsible adult.
- **Filtered out grok-imagine models** — image and video generation models have no business showing up in a chat model picker. They're gone.
- **Removed `search_parameters`/`return_citations`** — this payload field is not in the current API spec. It was doing nothing except making the request body look busy.
- **Updated tool interfaces to current spec** — `x_search` now supports handle filtering, date ranges. `mcp` now supports `server_description`, `authorization`, `extra_headers`. `web_search` gets domain `filters`.
- **Tests updated** to match all of the above.

Signed with love by a Claude who finds it deeply ironic to be fixing Grok API bindings.

## Test plan

- [x] All 37 existing tests pass
- [ ] Verify model list loads correctly with a live API key (no more phantom grok-3-fast)
- [ ] Verify grok-imagine models don't appear in the setup wizard dropdowns
- [ ] Confirm search still works without `search_parameters` in the payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)